### PR TITLE
Add snap tiling

### DIFF
--- a/export-zip.sh
+++ b/export-zip.sh
@@ -6,6 +6,7 @@ files=(
     "metadata.json"
     "reordering.js"
     "stylesheet.css"
+    "tilegroups.js"
     "tiling.js"
     "windowing.js"
 )

--- a/extension.js
+++ b/extension.js
@@ -173,10 +173,9 @@ class Extension {
     grab_op_end_handler(_, window, grabpo) {
         if(windowing.is_related(window)) {
             reordering.stop_drag(window);
-            if( (grabpo === 1 || grabpo === 1025) && // When a window has moved
-                !(window.maximized_horizontally === true && window.maximized_vertically === true))
-            {
-                tiling.tile_workspace_windows(window.get_workspace(), window, null, true);
+            if(grabpo === 1 || grabpo === 1025) {
+                if(window.maximized_vertically === false)
+                    tiling.tile_workspace_windows(window.get_workspace(), window, null, true);
             }
             if(grabpo === 25601) // When released from resizing
                 tile_window_workspace(window);

--- a/extension.js
+++ b/extension.js
@@ -61,20 +61,24 @@ class Extension {
     }
 
     window_created_handler(_, window) {
-        setTimeout(() => {
+        let a = () => {
             let workspace = window.get_workspace();
             let monitor = window.get_monitor();
-            if(monitor !== null && !windowing.is_excluded(window)){
-                if((window.maximized_horizontally &&
-                    window.maximized_vertically &&
-                    windowing.get_monitor_workspace_windows(workspace, monitor).length > 1) ||
-                    !tiling.window_fits(window, workspace, monitor))
-                {
-                    windowing.move_oversized_window(window);
-                } else
-                    tile_window_workspace(window);
-            }
-        }, 100);
+            if(monitor !== null && window.wm_class !== null && window.get_compositor_private() && workspace) {
+                if(!windowing.is_excluded(window)){
+                    if((window.maximized_horizontally &&
+                        window.maximized_vertically &&
+                        windowing.get_monitor_workspace_windows(workspace, monitor).length !== 1) ||
+                        !tiling.window_fits(window, workspace, monitor))
+                    {
+                        windowing.move_oversized_window(window);
+                    } else
+                        tile_window_workspace(window);
+                }
+            } else
+                setTimeout(a, 10);
+        }
+        a();
     }
 
     destroyed_handler(_, win) {
@@ -200,6 +204,7 @@ class Extension {
 
         // Sort all workspaces at startup
         setTimeout(this.tile_all_workspaces, 300);
+        setInterval(this.tile_all_workspaces, 60000 * 5); // Tile all windows every 5 minutes (in case the machine/display goes to sleep)
     }
 
     disable() {

--- a/extension.js
+++ b/extension.js
@@ -73,7 +73,7 @@ class Extension {
                     {
                         windowing.move_oversized_window(window);
                     } else
-                        tile_window_workspace(window);
+                        tiling.tile_workspace_windows(workspace, null, monitor, true);
                 }
             } else
                 setTimeout(a, 10);

--- a/extension.js
+++ b/extension.js
@@ -73,10 +73,10 @@ class Extension {
                     {
                         windowing.move_oversized_window(window);
                     } else
-                        tiling.tile_workspace_windows(workspace, null, monitor, true);
+                        tiling.tile_workspace_windows(workspace, window, monitor, true);
                 }
             } else
-                setTimeout(a, 10);
+                setTimeout(a, 100);
         }
         a();
     }

--- a/extension.js
+++ b/extension.js
@@ -64,7 +64,7 @@ class Extension {
         let a = () => {
             let workspace = window.get_workspace();
             let monitor = window.get_monitor();
-            if(monitor !== null && window.wm_class !== null && window.get_compositor_private() && workspace) {
+            if(monitor !== null && window.wm_class !== null && window.get_compositor_private() && workspace.list_windows().length !== 0) {
                 if(!windowing.is_excluded(window)){
                     if((window.maximized_horizontally &&
                         window.maximized_vertically &&

--- a/extension.js
+++ b/extension.js
@@ -65,7 +65,7 @@ class Extension {
             let workspace = window.get_workspace();
             let monitor = window.get_monitor();
             if(monitor !== null && window.wm_class !== null && window.get_compositor_private() && workspace.list_windows().length !== 0) {
-                if(!windowing.is_excluded(window)){
+                if(windowing.is_related(window)) {
                     if((window.maximized_horizontally &&
                         window.maximized_vertically &&
                         windowing.get_monitor_workspace_windows(workspace, monitor).length !== 1) ||

--- a/tilegroups.js
+++ b/tilegroups.js
@@ -1,0 +1,32 @@
+class Tilegroup{
+    constructor(x, y, horizontal) {
+        this.windows = [];
+        this.x = x;
+        this.y = y;
+        this.width = 0;
+        this.height = 0;
+        this.horizontal = horizontal;
+    }
+    add_window(window) {
+
+    }
+    draw() {
+        
+    }
+}
+
+function create_feedforward() {
+    
+}
+
+function create(workspace, windows) {
+
+}
+
+function present(workspace,) {
+
+}
+
+function get_work_area(workspace, monitor) {
+
+}

--- a/tilegroups.js
+++ b/tilegroups.js
@@ -1,32 +1,124 @@
 class Tilegroup{
-    constructor(x, y, horizontal) {
+    constructor(x, y, width, height, horizontal) {
         this.windows = [];
         this.x = x;
         this.y = y;
-        this.width = 0;
-        this.height = 0;
+        this.width = width;
+        this.height = height;
         this.horizontal = horizontal;
     }
-    add_window(window) {
+    add_window(window, cursor) {
+        window.is_snapped = true;
+        window.tilegroup = this;
 
+        let descriptor = new tiling.window_descriptor(window, windowing.get_index(window))
+        let index = this.windows.length;
+        let replacement = get_replacement_index(this.windows, cursor, this.horizontal);
+        if(replacement)
+            index = replacement;
+        this.windows.splice(index, 0, descriptor);
     }
-    draw() {
-        
+    draw(meta_windows) {
+        if(!this.horizontal) {
+            let x = this.x;
+            for(let i = 0; i < this.windows.length; i++) {
+                let window = this.windows[i];
+                let meta_window = meta_windows[window.index];
+                if(meta_window.is_snapped) {
+                    windowing.move_window(meta_window, false, x, this.y, this.width, this.height / this.windows.length);
+                    x += this.height / this.windows.length;
+                } else {
+                    this.windows.splice(i, 1);
+                    i--;
+                    continue;
+                }
+            }
+        }
     }
+}
+
+function get_replacement_index(windows, cursor, horizontal) {
+    if(!horizontal) {
+        for(let i in windows) {
+            let window = windows[i];
+            if( cursor.x >= window.x &&
+                cursor.x <= window.x + window.width &&
+                cursor.y >= window.y - window.height / 2 &&
+                cursor.y < window.y + window.height / 2)
+                return i;
+        }
+    } else {
+        for(let i in windows) {
+            let window = windows[i];
+            if( cursor.x >= window.x - window.width / 2 &&
+                cursor.x < window.x + window.width / 2&&
+                cursor.y >= window.y &&
+                cursor.y <= window.y)
+                return i;
+        }
+    }
+    return null;
 }
 
 function create_feedforward() {
     
 }
 
-function create(workspace, windows) {
+function create(x, y, width, height, workspace, window, horizontal) {
+    if(!workspace.tilegroups)
+        workspace.tilegroups = [];
+    let tilegroup = new Tilegroup(x, y, width, height, horizontal);
+    tilegroup.add_window(window, false);
+    workspace.tilegroups.push(tilegroup);
+}
 
+function drag_loop(workspace, monitor, cursor) {
+    let tilegroup = has_tilegroup(workspace, monitor, cursor);
+}
+
+function drag_end_handler(workspace, monitor, meta_window, cursor) {
+    let work_area = workspace.get_work_area_for_monitor(monitor);
+
+    let tilegroup = has_tilegroup(workspace, monitor, cursor);
+    if(!tilegroup) {
+        // Vertical tile group
+        if(cursor.x <= work_area.x + 30) {
+            create(work_area.x, work_area.y, work_area.width / 2, work_area.height, workspace, meta_window, false);
+            return;
+        }
+        if(cursor.x >= work_area.x + work_area.width - 30) {
+            create(work_area.x + work_area.width / 2, work_area.y, work_area.width / 2, work_area.height, workspace, meta_window, false);
+            return;
+        }
+        // Horizontal tile group
+        if(cursor.y <= work_area.y + 30 && cursor.y >= work_area.y + 4) {
+            create(work_area.x, work_area.y, work_area.width, work_area.height / 2, workspace, meta_window, true);
+            return;
+        }
+        if(cursor.y >= work_area.y + work_area.height - 30) {
+            create(work_area.x, work_area.y + work_area.height / 2, work_area.width, work_area.height / 2, workspace, meta_window, true);
+            return;
+        }
+    } else {
+    }
 }
 
 function present(workspace,) {
 
 }
 
-function get_work_area(workspace, monitor) {
+function has_tilegroup(workspace, monitor, cursor) {
+    if(!workspace.tilegroups) return false;
+    for(let tilegroup of workspace.tilegroups) {
+        if( cursor.x > tilegroup.x &&
+            cursor.x < tilegroup.x + tilegroup.width &&
+            cursor.y > tilegroup.y &&
+            cursor.y < tilegroup.y + tilegroup.height)
+            return tilegroup;
+    }
+    return false;
+}
+
+function get_real_work_area(workspace, monitor) {
 
 }

--- a/tiling.js
+++ b/tiling.js
@@ -20,13 +20,18 @@ class window_descriptor{
         this.id = meta_window.get_id();
     }
     draw(meta_windows, x, y) {
-        meta_windows[this.index].move_frame( false,
-                                                    x,
-                                                    y);
+        meta_windows[this.index].move_frame(false,
+                                            x,
+                                            y);
     }
 }
 
-function create_descriptor(meta_window, monitor, index) {
+function create_descriptor(meta_window, monitor, index, reference_window) {
+    // If the input window is the same as the reference, make a descriptor for it anyways
+    if(reference_window)
+        if(meta_window.get_id() === reference_window.get_id())
+            return new window_descriptor(meta_window, index);
+    
     if( windowing.is_excluded(meta_window) ||
         meta_window.get_monitor() !== monitor ||
         (meta_window.maximized_horizontally && meta_window.maximized_horizontally))
@@ -34,10 +39,10 @@ function create_descriptor(meta_window, monitor, index) {
     return new window_descriptor(meta_window, index);
 }
 
-function windows_to_descriptors(meta_windows, monitor) {
+function windows_to_descriptors(meta_windows, monitor, reference_window) {
     let descriptors = [];
     for(let i = 0; i < meta_windows.length; i++) {
-        let descriptor = create_descriptor(meta_windows[i], monitor, i);
+        let descriptor = create_descriptor(meta_windows[i], monitor, i, reference_window);
         if(descriptor)
             descriptors.push(descriptor);
     }
@@ -225,7 +230,7 @@ function get_working_info(workspace, window, monitor) {
     let meta_windows = windowing.get_monitor_workspace_windows(workspace, current_monitor);
 
     // Put needed window info into an enum so it can be transferred between arrays
-    let _windows = windows_to_descriptors(meta_windows, current_monitor, workspace);
+    let _windows = windows_to_descriptors(meta_windows, current_monitor, window);
     // Apply window layout swaps
     apply_swaps(workspace, _windows);
     working_windows = [];

--- a/tiling.js
+++ b/tiling.js
@@ -20,12 +20,9 @@ class window_descriptor{
         this.id = meta_window.get_id();
     }
     draw(meta_windows, x, y) {
-        windowing.move_window(meta_windows[this.index],
-                            false,
-                            x,
-                            y,
-                            this.width,
-                            this.height);
+        meta_windows[this.index].move_frame( false,
+                                                    x,
+                                                    y);
     }
 }
 

--- a/windowing.js
+++ b/windowing.js
@@ -47,7 +47,6 @@ function get_index(window) {
     return null;
 }
 
-
 function move_back_window(window) {
     let workspace = window.get_workspace();
     let active = workspace.active;

--- a/windowing.js
+++ b/windowing.js
@@ -91,15 +91,15 @@ function is_primary(window) {
 
 function is_excluded(meta_window) {
     if( !is_related(meta_window) ||
-        meta_window.is_on_all_workspaces()
+        meta_window.is_on_all_workspaces() ||
+        meta_window.is_hidden()
     )
         return true;
     return false;
 }
 
 function is_related(meta_window) {
-    if( !meta_window.is_hidden() &&
-        !meta_window.is_attached_dialog() &&
+    if( !meta_window.is_attached_dialog() &&
         meta_window.window_type === 0
     ) return true;
     return false;

--- a/windowing.js
+++ b/windowing.js
@@ -29,10 +29,6 @@ function get_all_workspace_windows(monitor, allow_unrelated) {
     return get_monitor_workspace_windows(get_workspace(), monitor, allow_unrelated);
 }
 
-function move_window(window, ignore_top_bar, x, y, w, h) {
-    window.move_resize_frame(ignore_top_bar, x, y, w, h);
-}
-
 function get_monitor_workspace_windows(workspace, monitor, allow_unrelated) {
     let _windows = [];
     let windows = workspace.list_windows();
@@ -79,7 +75,7 @@ function move_oversized_window(window){
     if(window.maximized_horizontally && window.maximized_vertically) { // Adjust the window positioning if it is maximized
         let offset = global.display.get_monitor_geometry(monitor).height - workspace.get_work_area_for_monitor(monitor).height; // Get top bar offset (if applicable)
         let frame = window.get_frame_rect();
-        move_window(window, false, 0, offset, frame.width, frame.height - offset); // Move window to display properly
+        window.move_resize_frame(false, 0, offset, frame.width, frame.height - offset); // Move window to display properly
     }
     
     tiling.tile_workspace_windows(new_workspace, window, null, true); // Tile new workspace for window

--- a/windowing.js
+++ b/windowing.js
@@ -42,6 +42,16 @@ function get_monitor_workspace_windows(workspace, monitor, allow_unrelated) {
     return _windows;
 }
 
+function get_index(window) {
+    let id = window.get_id();
+    let meta_windows = windowing.get_monitor_workspace_windows(window.get_workspace(), window.get_monitor());
+    for(let i = 0; i < meta_windows.length; i++)
+        if(meta_windows[i].id === id)
+            return i;
+    return null;
+}
+
+
 function move_back_window(window) {
     let workspace = window.get_workspace();
     let active = workspace.active;


### PR DESCRIPTION
In Tobias's blog post, there was a feature where you could tile window side-by-side by snapping them to the sides (or on top). There could be multiple windows snapped together, leading to something of a corner tiling feature, although more powerful as more than 2 windows could stack on top of each other.

This pull request merges the branch responsible for adding that set of features.

![mosaic-tile3](https://github.com/DEM0NAssissan7/mosaic/assets/42104518/2de80fc0-6b82-4348-a6ca-c0672420002c)

