### PR TITLE
Fix Fullscreen Window Overflow

### DIFF
--- a/tiling.js
+++ b/tiling.js
@@ -314,8 +314,8 @@ export function tile_workspace_windows(workspace, reference_meta_window, _monito
     if (workspace_windows.length <= 1) {
         overflow = false;
     } else {
-        for (let window of workspace_windows)
-            if (window.maximized_horizontally && window.maximized_vertically)
+        for(let window of workspace_windows)
+            if(window.maximized_horizontally && window.maximized_vertically)
                 overflow = true;
     }
   


### PR DESCRIPTION
When there is only 1 window in the current workspace it's impossible for it to create an overflow condition. This fixes a bug where opening a fullscreen app on an empty window moves it to the next workspace